### PR TITLE
updated the os code name upto android Q

### DIFF
--- a/easydeviceinfo-base/src/main/java/github/nisrulz/easydeviceinfo/base/EasyDeviceMod.java
+++ b/easydeviceinfo-base/src/main/java/github/nisrulz/easydeviceinfo/base/EasyDeviceMod.java
@@ -460,7 +460,14 @@ public class EasyDeviceMod {
         codename = "Nougat";
         break;
       case Build.VERSION_CODES.O:
-        codename = "O";
+      case Build.VERSION_CODES.O_MR1:
+        codename = "Oreo";
+        break;
+      case Build.VERSION_CODES.P:
+        codename = "Pie";
+        break;
+      case Build.VERSION_CODES.Q:
+        codename = "Q";
         break;
       default:
         codename = EasyDeviceInfo.notFoundVal;


### PR DESCRIPTION
Updated the os code name upto Android Q. Earlier it was showing unknown for Android 9 and above.