### PR TITLE
getDeviceType() tweaked

### DIFF
--- a/easydeviceinfo-base/src/main/java/github/nisrulz/easydeviceinfo/base/EasyDeviceMod.java
+++ b/easydeviceinfo-base/src/main/java/github/nisrulz/easydeviceinfo/base/EasyDeviceMod.java
@@ -190,10 +190,9 @@ public class EasyDeviceMod {
    */
 
   @DeviceType
-  public final int getDeviceType(Activity activity) {
-    DisplayMetrics metrics = new DisplayMetrics();
+  public final int getDeviceType() {
+    DisplayMetrics metrics = new Resources.getSystem().getDisplayMetrics();
     activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
-
     float yInches = metrics.heightPixels / metrics.ydpi;
     float xInches = metrics.widthPixels / metrics.xdpi;
     double diagonalInches = Math.sqrt(xInches * xInches + yInches * yInches);


### PR DESCRIPTION
Removed the need for an Activity in order to retrieve display information. The reason being that an Activity made the method invokes be strict, so you cannot call it from a service or a non-Activity place.
Now it is accessible anywhere...

